### PR TITLE
Issues/102 個人端檢視應徵記錄

### DIFF
--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -6,7 +6,7 @@
 <div class="container p-5 pb-24 mx-auto">
 
     {% if request.user.is_authenticated and request.user.type == 2 %}
-    <a class="text-white btn btn-primary min-w-20" href="{% url 'companies:jobs_new' company.id %}">新增職缺</a>
+    <a class="text-white btn btn-primary min-w-20" href="{% url 'companies:jobs_new' request.user.company.id %}">新增職缺</a>
     {% endif %}
 
 

--- a/apps/jobs/templates/jobs/show.html
+++ b/apps/jobs/templates/jobs/show.html
@@ -13,6 +13,10 @@
         <input type="hidden" name="job_id" value="{{ job.id }}">
         <button>應徵此工作</button>
       </form>
+    {% if backJobs %}
     <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:index' %}">返回列表</a>
+    {% else %}
+    <a class="text-white btn btn-primary min-w-20" href="{% url 'resumes:jobs' %}">返回</a>
+    {% endif %}
 </div>
 {% endblock %}

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect, render
 
@@ -23,7 +25,11 @@ def show(request, id):
             return redirect("jobs:show", job.id)
         else:
             return render(request, "jobs/edit.html", {"form": form, "job": job})
-    return render(request, "jobs/show.html", {"job": job})
+
+    previous_url = request.META.get("HTTP_REFERER", "/")
+    referer_path = urlparse(previous_url).path
+    backJobs = "resumes" not in referer_path
+    return render(request, "jobs/show.html", {"job": job, "backJobs": backJobs})
 
 
 def edit(request, id):

--- a/apps/resumes/templates/resumes/job.html
+++ b/apps/resumes/templates/resumes/job.html
@@ -1,0 +1,35 @@
+{% extends "layouts/base.html" %}
+{% block content %}
+<div class="mt-20 h-24 text-center bg-gray-100 flex justify-center items-center">
+    <h1 class="text-3xl font-bold">應徵紀錄</h1>
+</div>
+<div class="container p-5 pb-24 mx-auto">
+<p>你總共有 {{ job_resumes|length }} 次應徵紀錄。</p>
+    {% if job_resumes %}
+    <div class="overflow-x-auto mt-5">
+        <table class="table">
+            <thead>
+                <tr class="text-center text-base">
+                    <th></th>
+                    <th>職缺</th>
+                    <th>履歷</th>
+                    <th>應徵時間</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for job_resume in job_resumes %}
+                    <tr class="hover cursor-pointer" onclick="window.location.href= '{% url 'jobs:show' job_resume.job_id %}';" >
+                        <th>{{ forloop.counter }}</th>
+                        <td>{{ job_resume.job_title }}</td>
+                        <td>{{ job_resume.resume_file }}</td>
+                        <td>{{ job_resume.created_at }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+        <div class="text-center py-5"><p>尚無應徵紀錄</p></div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/apps/resumes/urls.py
+++ b/apps/resumes/urls.py
@@ -6,6 +6,7 @@ app_name = "resumes"
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("jobs", views.jobs, name="jobs"),
     path("upload/", views.upload, name="upload"),
     path("delete/<int:resume_id>/", views.delete_resume, name="delete"),
 ]

--- a/apps/resumes/views.py
+++ b/apps/resumes/views.py
@@ -46,7 +46,9 @@ def jobs(request):
     resume_file_subquery = Resume.objects.filter(id=OuterRef("resume_id")).values(
         "file"
     )[:1]
-    resume_subquery = Resume.objects.filter(userinfo__user_id=1).values("id")
+    resume_subquery = Resume.objects.filter(userinfo__user_id=request.user.id).values(
+        "id"
+    )
     job_resumes = Job_Resume.objects.filter(resume_id__in=resume_subquery).annotate(
         job_title=Subquery(job_title_subquery),
         resume_file=Subquery(resume_file_subquery),

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -18,3 +18,7 @@
 .no-style{
   @apply bg-transparent border-transparent shadow-none;
 }
+
+:root {
+  --fallback-b2:#f3f4f6;
+}

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -32,10 +32,11 @@
           <div class="cursor-pointer"><h2>{{ request.user }}，您好</h2></div>
           <div class="hidden absolute top-12 left-1/2 p-3 text-center bg-white rounded-xl divide-y shadow-lg -translate-x-1/2 divide-slate-200 group-hover:block">
             {% if request.user.type == 1 %}
-              <a class="block px-2.5 py-2 whitespace-nowrap" href="{% url 'users:info' request.user.pk %}">會員資料</a>
-              <a class="block px-2.5 py-2 whitespace-nowrap" href="{% url 'users:favorites_list' %}">我的職缺收藏</a>
-              <a class="block px-2.5 py-2 whitespace-nowrap" href="{% url 'users:favorites_company_list' %}">喜愛的公司</a>
-              <a class="block px-2.5 py-2 whitespace-nowrap" href="{% url 'resumes:index' %}">我的履歷</a>
+              <a class="block py-2 px-2.5 whitespace-nowrap" href="{% url 'users:info' request.user.pk %}">會員資料</a>
+              <a class="block py-2 px-2.5 whitespace-nowrap" href="{% url 'users:favorites_list' %}">我的職缺收藏</a>
+              <a class="block py-2 px-2.5 whitespace-nowrap" href="{% url 'users:favorites_company_list' %}">喜愛的公司</a>
+              <a class="block py-2 px-2.5 whitespace-nowrap" href="{% url 'resumes:index' %}">我的履歷</a>
+              <a class="block py-2 px-2.5 whitespace-nowrap" href="{% url 'resumes:jobs' %}">應徵紀錄</a>
             {% elif request.user.type == 2 %}
               <a class="block px-2.5 py-2 whitespace-nowrap" href="{% url 'companies:index' %}">公司資料</a>
             {% endif %}


### PR DESCRIPTION
個人端的下拉選單增加 [應徵記錄]
可以從應徵記錄連結到職缺內頁
若是從應徵記錄連結到職缺內頁會，顯示 [返回] 按鈕可回到應徵記錄 (原本從職缺進去的話會是 [返回列表] )


https://github.com/user-attachments/assets/739f2a2e-a654-44bd-aa67-65cc6452a286

