### PR TITLE
issues/95 修復_第三方導回到會員資訊問題&取消會錯誤的訊息

### DIFF
--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from django.views.generic import TemplateView
 
 from . import views
-from .views import PasswordResetDoneView, PasswordResetView
+from .views import PasswordResetDoneView, PasswordResetView, social_auth_complete
 
 app_name = "users"
 
@@ -37,4 +37,5 @@ urlpatterns = [
     ),
     path("<int:job_id>/apply/", views.apply_jobs, name="apply_jobs"),
     path("<int:job_id>/submit", views.submit_jobs, name="submit_jobs"),
+     path('social-auth/complete/<str:backend>/', social_auth_complete, name='social_auth_complete'),
 ]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -127,8 +127,6 @@ def info(request):
 
 def social_save_profile(backend, user, response, *args, **kwargs):
     request = kwargs.get("request")
-    if request is None:
-        return None
     
     match backend.name:
         case "line":
@@ -151,7 +149,6 @@ def social_save_profile(backend, user, response, *args, **kwargs):
     if not user_info or not user_info.nickname:
         return redirect("users:info", user.id)  
     return redirect('/')    
-
 
 @login_required
 def login_redirect(request):

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -146,7 +146,10 @@ def social_save_profile(backend, user, response, *args, **kwargs):
             pass
     backend_str = f'{backend.__module__}.{backend.__class__.__name__}'
     user.backend = backend_str
-    login(request, user, backend=backend_str)  
+    login(request, user, backend=backend_str)
+    user_info = UserInfo.objects.filter(user=user).first()
+    if not user_info or not user_info.nickname:
+        return redirect("users:info", user.id)  
     return redirect('/')    
 
 

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -126,7 +126,10 @@ def info(request):
 
 
 def social_save_profile(backend, user, response, *args, **kwargs):
-
+    request = kwargs.get("request")
+    if request is None:
+        return None
+    
     match backend.name:
         case "line":
             social_id = response["userId"]
@@ -141,6 +144,10 @@ def social_save_profile(backend, user, response, *args, **kwargs):
                 u1.save()
         case _:
             pass
+    backend_str = f'{backend.__module__}.{backend.__class__.__name__}'
+    user.backend = backend_str
+    login(request, user, backend=backend_str)  
+    return redirect('/')    
 
 
 @login_required


### PR DESCRIPTION
現在第三方登入之後,沒有填寫資訊就導去會員填寫,如果有就去首頁
現在第三方登入如果取消會回到登入畫面並且新增flash的訊息
也無法在登入情況下透過url進入到登入的網址,避免重複登入出現錯誤的情況

https://github.com/user-attachments/assets/763e1bd8-fcde-4ba0-9a88-bb9cd1861ccf

https://github.com/user-attachments/assets/4cf09c62-bc6d-4c3b-b317-08d39d82d879




