### PR TITLE
Issues/234 修復_公司帳號點選職缺show頁面會報錯

### DIFF
--- a/apps/companies/forms/companies_form.py
+++ b/apps/companies/forms/companies_form.py
@@ -1,5 +1,5 @@
 from django.forms import ModelForm
-from django.forms.widgets import EmailInput, FileInput, NumberInput, Textarea, TextInput, URLInput
+from django.forms.widgets import EmailInput, NumberInput, Textarea, TextInput, URLInput
 
 from apps.companies.models import Company
 
@@ -19,14 +19,31 @@ class CompanyForm(ModelForm):
         ]
 
         widgets = {
-            "title": TextInput(attrs={"class": "input-often-base","placeholder": "請輸入公司名稱"}),
-            "tel": TextInput(attrs={"class": "input-often-base","placeholder": "請輸入公司電話"}),
-            "url": URLInput(attrs={"class": "input-often-base","placeholder": "http://",}),
-            "address": TextInput(attrs={"class": "input-often-base", "placeholder": "請輸入公司完整地址"}),
-            "description": Textarea(attrs={"class": "textarea-often-base", "placeholder": "請輸入公司描述"}),
+            "title": TextInput(
+                attrs={"class": "input-often-base", "placeholder": "請輸入公司名稱"}
+            ),
+            "tel": TextInput(
+                attrs={"class": "input-often-base", "placeholder": "請輸入公司電話"}
+            ),
+            "url": URLInput(
+                attrs={
+                    "class": "input-often-base",
+                    "placeholder": "http://",
+                }
+            ),
+            "address": TextInput(
+                attrs={"class": "input-often-base", "placeholder": "請輸入公司完整地址"}
+            ),
+            "description": Textarea(
+                attrs={"class": "textarea-often-base", "placeholder": "請輸入公司描述"}
+            ),
             "employees": NumberInput(attrs={"class": "input-often-base"}),
-            "name": TextInput(attrs={"class": "input-often-base", "placeholder": "請輸入姓名"}),
-            "email": EmailInput(attrs={"class": "input-often-base", "placeholder": "請輸入email"}),
+            "name": TextInput(
+                attrs={"class": "input-often-base", "placeholder": "請輸入姓名"}
+            ),
+            "email": EmailInput(
+                attrs={"class": "input-often-base", "placeholder": "請輸入email"}
+            ),
         }
 
         labels = {

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 {% block content %}
-<div class="flex justify-center items-center mt-20 h-24 text-center bg-gray-100">
+<div class="flex items-center justify-center h-24 mt-20 text-center bg-gray-100">
     <h1 class="text-3xl font-bold">職缺</h1>
 </div>
 <div class="container p-5 pb-24 mx-auto">
@@ -20,7 +20,7 @@
             <div class="flex gap-2">
                 {% if item.can_edit %}
                     <a class="text-white btn btn-primary btn-sm" href="{% url 'jobs:edit' item.job.id %}">編輯</a>
-                    <form method="POST" action="{% url 'jobs:delete' item.job.id %}"></form>
+                    <form method="POST" action="{% url 'jobs:delete' item.job.id %}">
                         {% csrf_token %}
                         <button class="text-white btn btn-error btn-sm">刪除</button>
                     </form>

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -55,24 +55,14 @@ def show(request, id):
     previous_url = request.META.get("HTTP_REFERER", "/")
     referer_path = urlparse(previous_url).path
     backJobs = "resumes" not in referer_path
+    status = True
 
-    if request.user.type == 1:
+    if request.user.is_authenticated and request.user.type == 1:
         user_info = UserInfo.objects.get(user=request.user)
         user_resume = Resume.objects.filter(userinfo=user_info).values_list(
             "id", flat=True
         )
         status = Job_Resume.objects.filter(job=job, resume__in=user_resume).exists()
-
-        return render(
-            request,
-            "jobs/show.html",
-            {
-                "job": job,
-                "backJobs": backJobs,
-                "tags": job.tags.all(),
-                "status": status,
-            },
-        )
 
     return render(
         request,
@@ -81,6 +71,7 @@ def show(request, id):
             "job": job,
             "backJobs": backJobs,
             "tags": job.tags.all(),
+            "status": status,
         },
     )
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -17,8 +17,6 @@ from .forms.jobs_form import JobForm
 from .models import Job, Job_Resume, JobFavorite
 
 
-
-
 def index(request):
     jobs = Job.objects.order_by("-id")
     favorites = JobFavorite.objects.filter(user=request.user).values_list(

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -17,6 +17,8 @@ from .forms.jobs_form import JobForm
 from .models import Job, Job_Resume, JobFavorite
 
 
+
+
 def index(request):
     jobs = Job.objects.order_by("-id")
     favorites = JobFavorite.objects.filter(user=request.user).values_list(
@@ -54,14 +56,21 @@ def show(request, id):
     referer_path = urlparse(previous_url).path
     backJobs = "resumes" not in referer_path
 
-    user_info = UserInfo.objects.get(user=request.user)
-    user_resume = Resume.objects.filter(userinfo=user_info).values_list("id", flat=True)
-    status = Job_Resume.objects.filter(job=job, resume__in=user_resume).exists()
+    if request.user.type == 1:
+        user_info = UserInfo.objects.get(user=request.user)
+        user_resume = Resume.objects.filter(userinfo=user_info).values_list("id", flat=True)
+        status = Job_Resume.objects.filter(job=job, resume__in=user_resume).exists()
+
+        return render(
+        request,
+        "jobs/show.html",
+        {"job": job, "backJobs": backJobs, "tags": job.tags.all(), "status": status},
+    )
 
     return render(
         request,
         "jobs/show.html",
-        {"job": job, "backJobs": backJobs, "tags": job.tags.all(), "status": status},
+        {"job": job, "backJobs": backJobs, "tags": job.tags.all(),},
     )
 
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -58,19 +58,30 @@ def show(request, id):
 
     if request.user.type == 1:
         user_info = UserInfo.objects.get(user=request.user)
-        user_resume = Resume.objects.filter(userinfo=user_info).values_list("id", flat=True)
+        user_resume = Resume.objects.filter(userinfo=user_info).values_list(
+            "id", flat=True
+        )
         status = Job_Resume.objects.filter(job=job, resume__in=user_resume).exists()
 
         return render(
-        request,
-        "jobs/show.html",
-        {"job": job, "backJobs": backJobs, "tags": job.tags.all(), "status": status},
-    )
+            request,
+            "jobs/show.html",
+            {
+                "job": job,
+                "backJobs": backJobs,
+                "tags": job.tags.all(),
+                "status": status,
+            },
+        )
 
     return render(
         request,
         "jobs/show.html",
-        {"job": job, "backJobs": backJobs, "tags": job.tags.all(),},
+        {
+            "job": job,
+            "backJobs": backJobs,
+            "tags": job.tags.all(),
+        },
     )
 
 


### PR DESCRIPTION
#234 

<img width="1097" alt="截圖 2024-09-21 17 41 44" src="https://github.com/user-attachments/assets/a1135601-bf36-41a4-af5f-11a6ca904147">


分流處理，只有登入方為個人使用戶，才會去抓 userinfo；公司方則不會

影片內容
一開始登入使用公司帳號，進入職缺頁面，點選職缺內容不會報錯（現在的版本會報錯）
之後登出使用一般用戶，進入職缺頁面，點選職缺內容，會根據該使用者是否有投遞過該職缺而決定顯示「應徵」按鈕

https://github.com/user-attachments/assets/e698d1c8-e460-4136-a9f7-8b2451f1f4c3

