### PR TITLE
Issues/216 首頁_塞資料

### DIFF
--- a/apps/jobs/models.py
+++ b/apps/jobs/models.py
@@ -5,32 +5,11 @@ from taggit.managers import TaggableManager
 from apps.companies.models import Company
 from apps.resumes.models import Resume
 from lib.models.soft_delete import SoftDeleteManager, SoftDeletetable
+from lib.utils.models.defined import LOCATION_CHOICES
 
 
 class Job(SoftDeletetable, models.Model):
     company = models.ForeignKey(Company, on_delete=models.CASCADE, related_name="jobs")
-    LOCATION_CHOICES = [
-        ("Keelung", "基隆"),
-        ("Taipei", "台北"),
-        ("New Taipei", "新北"),
-        ("Taoyuan", "桃園"),
-        ("Hsinchu", "新竹"),
-        ("Miaoli", "苗栗"),
-        ("Taichung", "台中"),
-        ("Changhua", "彰化"),
-        ("Nantou", "南投"),
-        ("Yunlin", "雲林"),
-        ("Chiayi", "嘉義"),
-        ("Tainan", "台南"),
-        ("Kaohsiung", "高雄"),
-        ("Pingtung", "屏東"),
-        ("Taitung", "台東"),
-        ("Hualien", "花蓮"),
-        ("Yilan", "宜蘭"),
-        ("Penghu", "澎湖"),
-        ("Kinmen", "金門"),
-        ("Lienchiang", "連江"),
-    ]
     title = models.CharField(max_length=100, null=False, blank=False)
     description = models.TextField()
     location = models.CharField(max_length=100, choices=LOCATION_CHOICES)

--- a/apps/users/templates/users/home.html
+++ b/apps/users/templates/users/home.html
@@ -12,12 +12,17 @@
       <form action="{% url 'jobs:search_results' %}" method="GET" class="flex flex-col w-full gap-1 px-4 pt-2 pb-4 bg-white shadow-md md:flex-row lg:flex-row md:items-center lg:items-center md:p-3 lg:p-4 md:gap-4 lg:gap-4 rounded-xl md:rounded-full lg:rounded-full">
         <div class="flex items-center flex-1">
           <div class="w-5 text-base text-center text-black md:w-7 lg:w-7 md:text-2xl lg:text-2xl"><i class="fa-solid fa-magnifying-glass"></i></div>
-          <input type="text" name="q" placeholder="請輸入工作名稱或公司" class="w-full px-2 py-2 text-base text-gray-500 placeholder-gray-500 bg-transparent border-transparent outline-none md:text-lg lg:text-lg" value="{{ request.GET.q }}"/>
+          <input type="text" name="q" placeholder="請輸入工作名稱或公司" class="w-full px-2 py-2 text-base text-gray-500 placeholder-gray-500 bg-transparent border-transparent outline-none md:text-lg lg:text-lg" value="{{ request.GET.q }}" />
         </div>
         <div class="w-full h-px bg-gray-300 md:w-px lg:w-px md:h-8 lg:h-8"></div>
         <div class="flex items-center flex-1">
           <div class="w-5 text-base text-center text-black md:w-7 lg:w-7 md:text-2xl lg:text-2xl"><i class="fa-solid fa-location-dot"></i></div>
-          <input type="text" name="location" placeholder="請輸入地點" class="w-full px-2 py-2 text-base text-gray-500 placeholder-gray-500 bg-transparent border-transparent outline-none md:text-lg lg:text-lg" value="{{ request.GET.location }}"/>
+          <select name="location" class="w-full px-2 py-2 text-base text-gray-500 bg-transparent border-transparent outline-none md:text-lg lg:text-lg">
+            <option value="">請選擇地點</option>
+            {% for value, label in locations %}
+                <option value="{{ value }}" {% if request.GET.location == value %} selected {% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
         </div>
         <div class="mt-2 md:m-0 lg:m-0">
           <button class="w-full btn btn-primary btn-sm md:btn-lg lg:btn-lg md:w-auto lg:w-auto md:min-w-28 lg:min-w-28">搜尋</button>
@@ -44,101 +49,46 @@
       <h2 class="mb-5 text-2xl font-bold lg:text-3xl lg:mb-9">熱門職缺</h2>
       <div class="flex flex-wrap gap-5 md:gap-7 lg:gap-10">
         <!--card-->
-        <div class="relative border border-[#cccccc] rounded-xl md:rounded-3xl lg:rounded-3xl p-5 md:p-6 lg:p-6 bg-white w-full md:w-calc-card lg:w-calc-card box-border">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
+        {% for job in jobs %}
+          <div class="relative border border-[#cccccc] rounded-xl md:rounded-3xl lg:rounded-3xl p-5 md:p-6 lg:p-6 bg-white w-full md:w-calc-card lg:w-calc-card box-border">
+            <div class="items-center block md:flex lg:flex">
+              <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
+                <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
+              </div>
+              <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
+                <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">
+                  <a href="{% url 'jobs:show' job.id %}">{{ job.title }}</a>
+                </h2>
+                <p class="text-sm font-light text-gray-600 md:text-base lg:text-base">
+                  <a href="{% url 'companies:show' job.company_id %}">{{ job.company }}</a>
+                </p>
+              </div>
+              {% if  request.user.is_authenticated and request.user.type == 1 %}
+                <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
+                  {% include "shared/job_favorite.html" with favorited=job.favorited%}
+                </div>
+              {% endif %}
             </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">Python後端工程師</h2>
-              <p class="text-sm font-light text-gray-600 md:text-base lg:text-base">麥當勞 McDonald's</p>
+            <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
+              <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{ job.type }}</span>
+              <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base">
+                <a href="{% url 'jobs:search_results' %}?location={{job.location}}">
+                  <i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i>
+                  {{ job.location_label }}</a>
+                </span>
+              <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> ${{ job.salary }} / 月</span>
             </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
-            </div>
-          </div>
-          <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
-            <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">遠距</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> 台北市</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> $50,000 / 月</span>
-          </div>
-          <div class="flex justify-between items-center mt-6 md:mt-4 lg:mt-4">
-            <div class="text-gray-500 text-xs md:text-base lg:text-base font-light">2024/07/12</div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">應徵</button>
-          </div>
-        </div>
-        <!--card-->
-        <div class="relative border border-[#cccccc] rounded-xl md:rounded-3xl lg:rounded-3xl p-5 md:p-6 lg:p-6 bg-white w-full md:w-calc-card lg:w-calc-card box-border">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-            </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">Python後端工程師</h2>
-              <p class="text-sm font-light text-gray-600 md:text-base lg:text-base">麥當勞 McDonald's</p>
-            </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
-            </div>
-          </div>
-          <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
-            <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">遠距</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> 台北市</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> $50,000 / 月</span>
-          </div>
-          <div class="flex justify-between items-center mt-6 md:mt-4 lg:mt-4">
-            <div class="text-gray-500 text-xs md:text-base lg:text-base font-light">2024/07/12</div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">應徵</button>
-          </div>
-        </div>
-        <!--card-->
-        <div class="relative border border-[#cccccc] rounded-xl md:rounded-3xl lg:rounded-3xl p-5 md:p-6 lg:p-6 bg-white w-full md:w-calc-card lg:w-calc-card box-border">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-            </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">Python後端工程師</h2>
-              <p class="text-sm font-light text-gray-600 md:text-base lg:text-base">麥當勞 McDonald's</p>
-            </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
+            <div class="flex justify-between items-center mt-6 md:mt-4 lg:mt-4">
+              <div class="text-gray-500 text-xs md:text-base lg:text-base font-light">{{ job.created_at|date:"Y/m/d" }}</div>
+              {% if request.user.type != 2 and not job.apply %}
+                <form action="{% url 'users:apply_jobs' job.id %}" method="POST">
+                  {% csrf_token%}
+                  <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">應徵</button>
+                </form>
+              {% endif %}
             </div>
           </div>
-          <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
-            <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">遠距</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> 台北市</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> $50,000 / 月</span>
-          </div>
-          <div class="flex justify-between items-center mt-6 md:mt-4 lg:mt-4">
-            <div class="text-gray-500 text-xs md:text-base lg:text-base font-light">2024/07/12</div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">應徵</button>
-          </div>
-        </div>
-        <!--card-->
-        <div class="relative border border-[#cccccc] rounded-xl md:rounded-3xl lg:rounded-3xl p-5 md:p-6 lg:p-6 bg-white w-full md:w-calc-card lg:w-calc-card box-border">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-            </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">Python後端工程師</h2>
-              <p class="text-sm font-light text-gray-600 md:text-base lg:text-base">麥當勞 McDonald's</p>
-            </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
-            </div>
-          </div>
-          <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
-            <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">遠距</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> 台北市</span>
-            <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> $50,000 / 月</span>
-          </div>
-          <div class="flex justify-between items-center mt-6 md:mt-4 lg:mt-4">
-            <div class="text-gray-500 text-xs md:text-base lg:text-base font-light">2024/07/12</div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">應徵</button>
-          </div>
-        </div>
+        {% endfor %}
       </div>
     </div>
   </div>
@@ -148,110 +98,41 @@
     <div class="container mx-auto">
       <h2 class="mb-5 text-2xl font-bold lg:text-3xl lg:mb-9">熱門企業</h2>
       <div class="flex flex-wrap gap-5 md:gap-7 lg:gap-10">
-        <!--card-->
-        <div class="box-border relative w-full p-6 bg-white rounded-xl md:rounded-3xl lg:rounded-3xl shadow-custom-light md:w-calc-card lg:w-calc-card">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-            </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">肯德基 KFC</h2>
-              <div class="flex items-center mt-px">
-                <i class="text-base fa-solid fa-star text-warning md:text-lg lg:text-lg"></i>
-                <span class="ml-2 text-base font-light md:text-xl lg:text-xl">4.9</span>
-                <div class="w-px h-4 bg-[#cccccc] mx-2"></div>
-                <span class="text-base font-light md:text-xl lg:text-xl">20個評論</span>
+        {% for company in companies %}
+          <div class="box-border relative w-full p-6 bg-white rounded-xl md:rounded-3xl lg:rounded-3xl shadow-custom-light md:w-calc-card lg:w-calc-card">
+            <div class="items-center block md:flex lg:flex">
+              <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
+                <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
               </div>
-            </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
-            </div>
-          </div>
-          <div class="flex items-center justify-between mt-4">
-            <div class="text-sm md:text-lg lg:text-lg font-light text-black flex-1 line-clamp-2 pr-2.5">
-                這是一家以炸雞等為主要產品的美國速食連鎖企業。全球150個國家/地區擁有30,000多家門市。
-            </div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">詳細</button>
-          </div>
-        </div>
-        <!--card-->
-        <div class="box-border relative w-full p-6 bg-white rounded-xl md:rounded-3xl lg:rounded-3xl shadow-custom-light md:w-calc-card lg:w-calc-card">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-            </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">肯德基 KFC</h2>
-              <div class="flex items-center mt-px">
-                <i class="text-base fa-solid fa-star text-warning md:text-lg lg:text-lg"></i>
-                <span class="ml-2 text-base font-light md:text-xl lg:text-xl">4.9</span>
-                <div class="w-px h-4 bg-[#cccccc] mx-2"></div>
-                <span class="text-base font-light md:text-xl lg:text-xl">20個評論</span>
+              <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
+                <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">
+                  <a href="{% url 'companies:show' company.id %}">{{ company.title }}</a>
+                </h2>
+                <div class="flex items-center mt-px">
+                  <i class="text-base fa-solid fa-star text-warning md:text-lg lg:text-lg"></i>
+                  <span class="ml-2 text-base font-light md:text-xl lg:text-xl">???</span>
+                  <div class="w-px h-4 bg-[#cccccc] mx-2"></div>
+                  <span class="text-base font-light md:text-xl lg:text-xl">
+                    <a href="{% url 'companies:post_index' company.id %}">{{ company.post_count }}個評論</a>
+                  </span>
+                </div>
               </div>
+              {% if request.user.is_authenticated and request.user.type == 1 %}
+                <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
+                  {% include "companies/favorite.html" with favorited=company.favorited %}
+                </div>
+              {% endif %}
             </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
-            </div>
-          </div>
-          <div class="flex items-center justify-between mt-4">
-            <div class="text-sm md:text-lg lg:text-lg font-light text-black flex-1 line-clamp-2 pr-2.5">
-                這是一家以炸雞等為主要產品的美國速食連鎖企業。全球150個國家/地區擁有30,000多家門市。
-            </div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">詳細</button>
-          </div>
-        </div>
-        <!--card-->
-        <div class="box-border relative w-full p-6 bg-white rounded-xl md:rounded-3xl lg:rounded-3xl shadow-custom-light md:w-calc-card lg:w-calc-card">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-            </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">肯德基 KFC</h2>
-              <div class="flex items-center mt-px">
-                <i class="text-base fa-solid fa-star text-warning md:text-lg lg:text-lg"></i>
-                <span class="ml-2 text-base font-light md:text-xl lg:text-xl">4.9</span>
-                <div class="w-px h-4 bg-[#cccccc] mx-2"></div>
-                <span class="text-base font-light md:text-xl lg:text-xl">20個評論</span>
+            <div class="flex items-center justify-between mt-4">
+              <div class="text-sm md:text-lg lg:text-lg font-light text-black flex-1 line-clamp-2 pr-2.5">
+                  {{ company.description }}
               </div>
-            </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
-            </div>
-          </div>
-          <div class="flex items-center justify-between mt-4">
-            <div class="text-sm md:text-lg lg:text-lg font-light text-black flex-1 line-clamp-2 pr-2.5">
-                這是一家以炸雞等為主要產品的美國速食連鎖企業。全球150個國家/地區擁有30,000多家門市。
-            </div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">詳細</button>
-          </div>
-        </div>
-        <!--card-->
-        <div class="box-border relative w-full p-6 bg-white rounded-xl md:rounded-3xl lg:rounded-3xl shadow-custom-light md:w-calc-card lg:w-calc-card">
-          <div class="items-center block md:flex lg:flex">
-            <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
-              <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-            </div>
-            <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
-              <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">肯德基 KFC</h2>
-              <div class="flex items-center mt-px">
-                <i class="text-base fa-solid fa-star text-warning md:text-lg lg:text-lg"></i>
-                <span class="ml-2 text-base font-light md:text-xl lg:text-xl">4.9</span>
-                <div class="w-px h-4 bg-[#cccccc] mx-2"></div>
-                <span class="text-base font-light md:text-xl lg:text-xl">20個評論</span>
-              </div>
-            </div>
-            <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-              <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
+              <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">
+                <a href="{% url 'companies:show' company.id %}">詳細</a>
+              </button>
             </div>
           </div>
-          <div class="flex items-center justify-between mt-4">
-            <div class="text-sm md:text-lg lg:text-lg font-light text-black flex-1 line-clamp-2 pr-2.5">
-                這是一家以炸雞等為主要產品的美國速食連鎖企業。全球150個國家/地區擁有30,000多家門市。
-            </div>
-            <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full">詳細</button>
-          </div>
-        </div>
+        {% endfor %}
       </div>
     </div>
   </div>

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.views.generic import TemplateView
 
 from . import views
 from .views import PasswordResetDoneView, PasswordResetView, social_auth_complete
@@ -42,4 +41,5 @@ urlpatterns = [
         social_auth_complete,
         name="social_auth_complete",
     ),
+    path("<int:job_id>/job_favorite/", views.job_favorite, name="job_favorite"),
 ]

--- a/src/scripts/fontawesome.js
+++ b/src/scripts/fontawesome.js
@@ -20,8 +20,23 @@ import {
   faHeart as farHeart,
 } from "@fortawesome/free-regular-svg-icons";
 
-
-library.add(fasThumbsDown, farThumbsDown, fasThumbsUp, farThumbsUp,farBell,fasBell, fasHeart, farHeart, fasUser ,fasCaretDown ,fasStar , fasLocationDot,fasMagnifyingGlass,fasSackDollar,fasPen);
+library.add(
+  fasThumbsDown,
+  farThumbsDown,
+  fasThumbsUp,
+  farThumbsUp,
+  farBell,
+  fasBell,
+  fasHeart,
+  farHeart,
+  fasUser,
+  fasCaretDown,
+  fasStar,
+  fasLocationDot,
+  fasMagnifyingGlass,
+  fasSackDollar,
+  fasPen
+);
 dom.i2svg();
 
 Alpine.data("reactions_post", () => ({
@@ -31,6 +46,12 @@ Alpine.data("reactions_post", () => ({
 }));
 
 Alpine.data("company_favorite", () => ({
+  init() {
+    dom.i2svg();
+  },
+}));
+
+Alpine.data("job_favorite", () => ({
   init() {
     dom.i2svg();
   },

--- a/templates/shared/job_favorite.html
+++ b/templates/shared/job_favorite.html
@@ -1,0 +1,10 @@
+<form x-data="job_favorite"
+hx-post="{% url 'users:job_favorite' job.id %}"
+hx-swap="outerHTML">
+  {%csrf_token%}
+  {% if favorited %}
+    <button class="text-error"><i class="fa-solid fa-heart"></i></button>
+  {% else %}
+    <button class="text-[#cccccc]"><i class="fa-regular fa-heart"></i></button>
+  {% endif %}
+</form>


### PR DESCRIPTION
### 1. 搜尋地點改成下拉選單
### 2. 塞資料 & 超連結
#### 職缺
+ 標題 => 職缺頁
+ 公司 => 公司頁
+ 地點 => 搜尋地點
+ 應徵按鈕 => 應徵頁面 (目前應徵過的不會顯示按鈕，之後可能會換成取消應徵?)
#### 公司
+ 標題 & 詳細按鈕 => 公司頁
+ 評論數量 => 評論列表

[未登入]
不會顯示收藏愛心

[公司方]
不會顯示收藏愛心 & 應徵

### 公司分數目前 company model 沒有紀錄，要另外開票處理


https://github.com/user-attachments/assets/86bd01e5-7f22-412d-844e-f041c38700a9

