### PR TITLE
Issues/242 切版_職缺首頁

### DIFF
--- a/apps/companies/templates/companies/index.html
+++ b/apps/companies/templates/companies/index.html
@@ -1,19 +1,19 @@
 {% extends "layouts/base.html" %}
 {% block content %}
 {% load static %}
-<div class="flex items-center justify-center h-44 md:h-80 lg:h-80 text-center relative overflow-hidden">
-    <h1 class="text-3xl md:text-5xl lg:text-5xl text-white font-bold relative z-20">公司列表</h1>
-    <div class="absolute z-10 m-auto inset-0 bg-cover bg-banner-img bg-center bg-fixed"></div>
+<div class="relative flex items-center justify-center overflow-hidden text-center h-44 md:h-80 lg:h-80">
+    <h1 class="relative z-20 text-3xl font-bold text-white md:text-5xl lg:text-5xl">公司列表</h1>
+    <div class="absolute inset-0 z-10 m-auto bg-fixed bg-center bg-cover bg-banner-img"></div>
     <div class="absolute z-10 m-auto inset-0 bg-gradient-to-b from-[rgba(68,157,209,0.9)] to-[rgba(0,51,107,0.9)]"></div>
 </div>
 
 <div class="bg-[#eef0f0]">
-    <div class="container px-5 pt-10 pb-16 lg:pt-20 lg:pb-24 mx-auto">
+    <div class="container px-5 pt-10 pb-16 mx-auto lg:pt-20 lg:pb-24">
         <div class="mb-6 md:mb-12 lg:mb-12">
             <form action="#" method="GET" class="flex items-center md:items-center lg:items-center px-4 py-2 md:p-3 lg:p-3 gap-1 md:gap-4 lg:gap-4 w-full bg-white rounded-full border border-[#e7e8eb]">
                 <div class="flex items-center flex-1">
-                  <div class="w-5 md:w-7 lg:w-7 text-black text-base md:text-2xl lg:text-2xl text-center"><i class="fa-solid fa-magnifying-glass"></i></div>
-                  <input type="text" name="q" placeholder="請輸入工作名稱或公司" class="outline-none bg-transparent border-transparent px-2 py-2 w-full text-gray-500 placeholder-gray-500 text-base md:text-lg lg:text-lg" />
+                  <div class="w-5 text-base text-center text-black md:w-7 lg:w-7 md:text-2xl lg:text-2xl"><i class="fa-solid fa-magnifying-glass"></i></div>
+                  <input type="text" name="q" placeholder="請輸入工作名稱或公司" class="w-full px-2 py-2 text-base text-gray-500 placeholder-gray-500 bg-transparent border-transparent outline-none md:text-lg lg:text-lg" />
                 </div>
                 <div>
                   <button class="btn btn-primary btn-sm md:btn-lg lg:btn-lg md:min-w-28 lg:min-w-28">搜尋</button>
@@ -23,17 +23,17 @@
         <ul class="flex flex-col gap-8">
             {% for item in page_obj %}
                 <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl bg-white border border-[#e7e8eb] p-6 bg-white w-full box-border">
-                    <div class="block md:flex lg:flex items-center">
-                        <div class="w-20 h-20 rounded-full bg-gray-200 relative overflow-hidden mx-auto md:mx-0 lg:mx-0">
-                        <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+                    <div class="items-center block md:flex lg:flex">
+                        <div class="relative w-20 h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
+                        <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
                         </div>
-                        <div class="pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4 flex-1 box-border">
-                        <h2 class="text-xl md:text-2xl lg:text-2xl font-semibold"><a href="{% url 'companies:show' item.company.id %}">{{ item.company.title }}</a></h2>
+                        <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:px-4 lg:px-4">
+                        <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl"><a href="{% url 'companies:show' item.company.id %}">{{ item.company.title }}</a></h2>
                         <div class="flex items-center mt-px">
-                            <i class="fa-solid fa-star text-warning text-base md:text-lg lg:text-lg"></i>
-                            <span class="text-base md:text-lg lg:text-lg font-light ml-1">4.9</span>
+                            <i class="text-base fa-solid fa-star text-warning md:text-lg lg:text-lg"></i>
+                            <span class="ml-1 text-base font-light md:text-lg lg:text-lg">4.9</span>
                             <div class="w-px h-4 bg-[#cccccc] mx-2"></div>
-                            <span class="text-base md:text-lg lg:text-lg font-light">20個評論</span>
+                            <span class="text-base font-light md:text-lg lg:text-lg">20個評論</span>
                         </div>
                         </div>
                         <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
@@ -42,14 +42,14 @@
                             {% endif %}
                         </div>
                     </div>
-                    <div class="flex flex-col md:flex-row lg:flex-row gap-4 lg:gap-0 justify-between items-center mt-4">
+                    <div class="flex flex-col items-center justify-between gap-4 mt-4 md:flex-row lg:flex-row lg:gap-0">
                         <div class="w-full md:w-auto lg:w-auto text-sm md:text-lg lg:text-lg font-light text-black flex-1 line-clamp-2 lg:pr-2.5">
                             {{ item.company.description }}
                         </div>
-                        <div class="flex items-center gap-2 w-full md:w-auto lg:w-auto">
-                            <a href="{% url 'companies:show' item.company.id %}" class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 rounded-full flex-auto lg:flex-none">詳細</a>
+                        <div class="flex items-center w-full gap-2 md:w-auto lg:w-auto">
+                            <a href="{% url 'companies:show' item.company.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
                             {% if item.can_edit %}
-                                <a class="btn btn-secondary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl rounded-full flex-auto lg:flex-none" href="{% url 'companies:edit' item.company.id %}"><i class="fa-solid fa-pen text-base lg:text-base"></i> <span>編輯</span></a>
+                                <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'companies:edit' item.company.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
                             {% endif %}
                         </div>
                     </div>

--- a/apps/companies/templates/companies/show.html
+++ b/apps/companies/templates/companies/show.html
@@ -54,11 +54,11 @@
             </div>
           </div>
         </div>
-    
+
         <div class="font-light text-base md:text-xl lg:text-xl mb-10 md:mb-20 lg:mb-20">
           <div class="leading-loose">{{ company.description }}</div>
         </div>
-    
+
         <div class="mb-10 md:mb-20 lg:mb-20">
           <div class="flex justify-between">
             <h2 class="text-xl md:text-2xl lg:text-3xl font-medium mb-7">公司職缺列表</h2>
@@ -67,7 +67,7 @@
             {% elif jobs|length > 0  %}
               <a class="text-white btn btn-primary min-w-20" href="{% url 'companies:jobs_index' company.id %}">全部職缺</a>
             {% endif %}
-            
+
           </div>
           <ul class="flex flex-col gap-6 md:gap-8 lg:gap-8">
             <!--card-->
@@ -163,7 +163,7 @@
           </ul>
         </div>
       </div>
-      
+
       <div class="flex gap-5 justify-center">
         <a class="btn btn-primary btn-sm md:btn-lg lg:btn-lg md:min-w-28 lg:min-w-28" href="{% url 'companies:index' %}">返回列表</a>
       </div>

--- a/apps/companies/views.py
+++ b/apps/companies/views.py
@@ -198,10 +198,13 @@ def post_new(request, id):
 
 def jobs_index(request, id):
     company = get_object_or_404(Company, id=id)
-    jobs = Job.objects.filter(company=company).order_by("-created_at")
+    jobs = (
+        Job.objects.filter(company=company)
+        .order_by("-created_at")
+        .select_related("company")
+    )
     jobs_with_permissions = [
-        {"job": job, "can_edit": rules.test_rule("can_edit_job", request.user, job.id)}
-        for job in jobs
+        {"job": job, "can_edit": True, "company": job.company} for job in jobs
     ]
     page_obj = paginate_queryset(request, jobs_with_permissions, 10)
 

--- a/apps/companies/views.py
+++ b/apps/companies/views.py
@@ -11,15 +11,15 @@ from apps.jobs.forms import JobForm
 from apps.jobs.models import Job, Job_Resume, JobFavorite
 from apps.posts.forms.posts_form import PostForm
 from apps.posts.models import Post
+from apps.resumes.models import Resume
+from apps.users.models import UserInfo
 from lib.models.paginate import paginate_queryset
 from lib.models.rule_required import rule_required
 from lib.utils.models.decorators import company_required
+from lib.utils.models.defined import LOCATION_CHOICES
 
 from .forms.companies_form import CompanyForm
 from .models import Company
-from apps.resumes.models import Resume
-from apps.users.models import UserInfo
-from lib.utils.models.defined import LOCATION_CHOICES
 
 
 def index(request):
@@ -197,7 +197,8 @@ def post_new(request, id):
 
 
 def jobs_index(request, id):
-    jobs = Job.objects.order_by("-id").select_related("company")
+    company = get_object_or_404(Company, id=id)
+    jobs = Job.objects.filter(company=company).order_by("-id").select_related("company")
     jobs_with_permissions = [
         {
             "id": job.id,

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -22,79 +22,55 @@
             </form>
         </div>
 
-{% if request.user.is_authenticated and request.user.type == 2 %}
-    <div class="container p-5 pb-24 mx-auto">
-        <a class="text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24" href="{% url 'companies:jobs_new' request.user.company.id %}">新增職缺</a>
-    </div>
-{% endif %}
-
-    <ul class="flex flex-col gap-8">
-        {% for item in page_obj %}
-        <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl bg-white border border-[#e7e8eb] p-6 bg-white w-full box-border">
-            <div class="items-center block md:flex lg:flex">
-              <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:pr-4 lg:pr-4">
-                <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{item.job.title}}</h2>
-              </div>
-              <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-                <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
-              </div>
+        {% if request.user.is_authenticated and request.user.type == 2 %}
+            <div class="container p-5 pb-24 mx-auto">
+                <a class="text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24" href="{% url 'companies:jobs_new' request.user.company.id %}">新增職缺</a>
             </div>
-            <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{item.job.description}}</p>
-            <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
-              <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{item.job.type}}</span>
-              <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> {{item.job.get_location_display}}</span>
-              <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> ${{item.job.salary_range}} / 月</span>
-            </div>
-            <div class="flex items-center justify-between mt-6 md:mt-4 lg:mt-4">
-              <div class="text-xs font-light text-gray-500 md:text-base lg:text-base">2024/07/12</div>
-              <a href="{% url 'jobs:show' item.job.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
-              {% if item.can_edit %}
-              <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' item.job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
-              <form method="POST" action="{% url 'jobs:delete' item.job.id %}"></form>
-                  {% csrf_token %}
-                  <button class="text-white btn btn-error btn-sm">刪除</button>
-              </form>
-          {% endif %}
-          
+        {% endif %}
 
-          {% if request.user.is_authenticated and request.user.type == 1 %}
-          {% if item.job.id in favorites %}
-          <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">取消</a>
-          {% else %}
-          <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
-          {% endif %}
-          {% endif %}
-
-            </div>
-          </li>
-          {% endfor %}
+        <ul class="flex flex-col gap-8">
+            {% for item in page_obj %}
+                <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl bg-white border border-[#e7e8eb] p-6 bg-white w-full box-border">
+                    <div class="items-center block md:flex lg:flex">
+                        <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:pr-4 lg:pr-4">
+                            <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{item.job.title}}</h2>
+                        </div>
+                        <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
+                            <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
+                        </div>
+                    </div>
+                    <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{item.job.description}}</p>
+                    <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
+                        <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{item.job.type}}</span>
+                        <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> {{item.job.get_location_display}}</span>
+                        <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> ${{item.job.salary_range}} / 月</span>
+                    </div>
+                    <div class="flex items-center justify-between mt-6 md:mt-4 lg:mt-4">
+                        <div class="text-xs font-light text-gray-500 md:text-base lg:text-base">2024/07/12</div>
+                        <div class="flex items-center w-full gap-2 md:w-auto lg:w-auto">
+                            <a href="{% url 'jobs:show' item.job.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
+                            {% if item.can_edit %}
+                                <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' item.job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
+                                <form method="POST" action="{% url 'jobs:delete' item.job.id %}"></form>
+                                    {% csrf_token %}
+                                    <button class="text-white btn btn-error btn-sm">刪除</button>
+                                </form>
+                            {% endif %}
+                            {% if request.user.is_authenticated and request.user.type == 1 %}
+                                {% if item.job.id in favorites %}
+                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">取消</a>
+                                {% else %}
+                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
+                                {% endif %}
+                            {% endif %}
+                        </div>    
+                    </div>
+                </li>
+            {% endfor %}
         </ul>
         {% include 'shared/_pagination.html' %}
-      </div>
-
-
-
+    </div>
+</div>
 {% endblock %}
 
 
-     <!-- <li class="flex gap-2 p-5">
-            <div class="flex-1">
-                {{ item.job.title }}
-            </div>
-            <div class="flex gap-2">
-                {% if item.can_edit %}
-                    <a class="text-white btn btn-primary btn-sm" href="{% url 'jobs:edit' item.job.id %}">編輯</a>
-                    <form method="POST" action="{% url 'jobs:delete' item.job.id %}">
-                        {% csrf_token %}
-                        <button class="text-white btn btn-error btn-sm">刪除</button>
-                    </form>
-                {% endif %}
-                {% if request.user.is_authenticated and request.user.type == 1 %}
-                {% if item.favorited %}
-                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">取消</a>
-                {% else %}
-                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
-                {% endif %}
-                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:apply_jobs' item.job.id %}" >應徵</a>
-                {% endif %}
-            </div>

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -1,8 +1,27 @@
 {% extends "layouts/base.html" %}
 {% block content %}
-<div class="flex items-center justify-center h-24 mt-20 text-center bg-gray-100">
-    <h1 class="text-3xl font-bold">職缺</h1>
+{% load static %}
+<div class="relative flex items-center justify-center overflow-hidden text-center h-44 md:h-80 lg:h-80">
+    <h1 class="relative z-20 text-3xl font-bold text-white md:text-5xl lg:text-5xl">職缺列表</h1>
+    <div class="absolute inset-0 z-10 m-auto bg-fixed bg-center bg-cover bg-banner-img"></div>
+    <div class="absolute z-10 m-auto inset-0 bg-gradient-to-b from-[rgba(68,157,209,0.9)] to-[rgba(0,51,107,0.9)]"></div>
 </div>
+
+<!--search bar-->
+<div class="bg-[#eef0f0]">
+    <div class="container px-5 pt-10 pb-16 mx-auto lg:pt-20 lg:pb-24">
+        <div class="mb-6 md:mb-12 lg:mb-12">
+            <form action="#" method="GET" class="flex items-center md:items-center lg:items-center px-4 py-2 md:p-3 lg:p-3 gap-1 md:gap-4 lg:gap-4 w-full bg-white rounded-full border border-[#e7e8eb]">
+                <div class="flex items-center flex-1">
+                  <div class="w-5 text-base text-center text-black md:w-7 lg:w-7 md:text-2xl lg:text-2xl"><i class="fa-solid fa-magnifying-glass"></i></div>
+                  <input type="text" name="q" placeholder="請輸入工作名稱或公司" class="w-full px-2 py-2 text-base text-gray-500 placeholder-gray-500 bg-transparent border-transparent outline-none md:text-lg lg:text-lg" />
+                </div>
+                <div>
+                  <button class="btn btn-primary btn-sm md:btn-lg lg:btn-lg md:min-w-28 lg:min-w-28">搜尋</button>
+                </div>
+            </form>
+        </div>
+
 <div class="container p-5 pb-24 mx-auto">
 
     {% if request.user.is_authenticated and request.user.type == 2 %}

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -22,19 +22,64 @@
             </form>
         </div>
 
-<div class="container p-5 pb-24 mx-auto">
+{% if request.user.is_authenticated and request.user.type == 2 %}
+    <div class="container p-5 pb-24 mx-auto">
+        <a class="text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24" href="{% url 'companies:jobs_new' request.user.company.id %}">新增職缺</a>
+    </div>
+{% endif %}
 
-    {% if request.user.is_authenticated and request.user.type == 2 %}
-    <a class="text-white btn btn-primary min-w-20" href="{% url 'companies:jobs_new' request.user.company.id %}">新增職缺</a>
-    {% endif %}
-
-
-    <ul class="mt-6 divide-y divide-slate-200">
+    <ul class="flex flex-col gap-8">
         {% for item in page_obj %}
-        <li class="flex gap-2 p-5">
+        <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl bg-white border border-[#e7e8eb] p-6 bg-white w-full box-border">
+            <div class="items-center block md:flex lg:flex">
+              <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:pr-4 lg:pr-4">
+                <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{item.job.title}}</h2>
+              </div>
+              <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
+                <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
+              </div>
+            </div>
+            <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{item.job.description}}</p>
+            <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
+              <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{item.job.type}}</span>
+              <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> {{item.job.get_location_display}}</span>
+              <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> ${{item.job.salary_range}} / 月</span>
+            </div>
+            <div class="flex items-center justify-between mt-6 md:mt-4 lg:mt-4">
+              <div class="text-xs font-light text-gray-500 md:text-base lg:text-base">2024/07/12</div>
+              <a href="{% url 'jobs:show' item.job.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
+              {% if item.can_edit %}
+              <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' item.job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
+              <form method="POST" action="{% url 'jobs:delete' item.job.id %}"></form>
+                  {% csrf_token %}
+                  <button class="text-white btn btn-error btn-sm">刪除</button>
+              </form>
+          {% endif %}
+          
+
+          {% if request.user.is_authenticated and request.user.type == 1 %}
+          {% if item.job.id in favorites %}
+          <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">取消</a>
+          {% else %}
+          <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
+          {% endif %}
+          {% endif %}
+
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+        {% include 'shared/_pagination.html' %}
+      </div>
+
+
+
+{% endblock %}
+
+
+     <!-- <li class="flex gap-2 p-5">
             <div class="flex-1">
                 {{ item.job.title }}
-                <a href="{% url 'jobs:show' item.job.id %}">{{ item.job.get_location_display }}</a>
             </div>
             <div class="flex gap-2">
                 {% if item.can_edit %}
@@ -53,10 +98,3 @@
                     <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:apply_jobs' item.job.id %}" >應徵</a>
                 {% endif %}
             </div>
-        </li>
-        {% endfor %}
-    </ul>
-    {% include 'shared/_pagination.html' %}
-</div>
-{% endblock %}
-

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -29,41 +29,42 @@
         {% endif %}
 
         <ul class="flex flex-col gap-8">
-            {% for item in page_obj %}
+            {% for job in page_obj %}
                 <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl bg-white border border-[#e7e8eb] p-6 bg-white w-full box-border">
                     <div class="items-center block md:flex lg:flex">
                         <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:pr-4 lg:pr-4">
-                            <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{item.job.title}}</h2>
+                            <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{job.title}}</h2>
                         </div>
                         <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-                            <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
+                            {% if  request.user.is_authenticated and request.user.type == 1 %}
+
+                                <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
+                                    {% include "shared/job_favorite.html" with favorited=favorited %}
+                                </div>
+                            {% endif %}
+
                         </div>
                     </div>
-                    <h3 class="mt-2 text-sm font-bold text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">from <a href="{% url 'companies:show' item.company.id %}">{{item.company.title}}</a></h3>
-                    <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{item.job.description}}</p>
+                    <h3 class="mt-2 text-sm font-bold text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">from <a href="{% url 'companies:show' job.company_id %}">{{job.company}}</a></h3>
+                    <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{job.description}}</p>
                     <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
-                        <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{item.job.type}}</span>
-                        <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> {{item.job.get_location_display}}</span>
-                        <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> ${{item.job.salary_range}} / 月</span>
+                        <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{job.type}}</span>
+                        <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-location-dot md:text-sm lg:text-sm"></i> {{job.get_location_display}}</span>
+                        <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> ${{job.salary_range}} / 月</span>
                     </div>
                     <div class="flex items-center justify-between mt-6 md:mt-4 lg:mt-4">
                         <div class="text-xs font-light text-gray-500 md:text-base lg:text-base">2024/07/12</div>
                         <div class="flex items-center w-full gap-2 md:w-auto lg:w-auto">
-                            <a href="{% url 'jobs:show' item.job.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
+                            <a href="{% url 'jobs:show' job.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
                             {% if item.can_edit %}
-                                <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' item.job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
-                                <form method="POST" action="{% url 'jobs:delete' item.job.id %}">
+                                <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
+                                <form method="POST" action="{% url 'jobs:delete' job.id %}">
                                     {% csrf_token %}
                                     <button class="text-white btn btn-error btn-sm">刪除</button>
                                 </form>
                             {% endif %}
-                            {% if  request.user.is_authenticated and request.user.type == 1 %}
-                                {% if item.job.id in favorites %}
-                                    <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-                                        {% include "shared/job_favorite.html" with favorited=item.favorited %}
-                                    </div>
-                                {% endif %}
-                            {% endif %}
+
+
                         </div>
                     </div>
                 </li>

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -53,7 +53,7 @@
                                 <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' item.job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
                                 <form method="POST" action="{% url 'jobs:delete' item.job.id %}">
                                     {% csrf_token %}
-                                    <button class="text-white btn btn-error btn-sm">刪除</button>
+                                    <button class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">刪除</button>
                                 </form>
                             {% endif %}
                             {% if request.user.is_authenticated and request.user.type == 1 %}

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -36,7 +36,16 @@
                             <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{item.job.title}}</h2>
                         </div>
                         <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-                            <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
+                            <div class="text-[#cccccc] cursor-pointer">
+                                {% if request.user.is_authenticated and request.user.type == 1 %}
+                                {% if item.job.id in favorites %}
+                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">取消</a>
+                                {% else %}
+                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
+                                {% endif %}
+                            {% endif %}
+                                <i class="fa-regular fa-heart"></i>
+                            </div>
                         </div>
                     </div>
                     <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{item.job.description}}</p>
@@ -55,13 +64,6 @@
                                     {% csrf_token %}
                                     <button class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">刪除</button>
                                 </form>
-                            {% endif %}
-                            {% if request.user.is_authenticated and request.user.type == 1 %}
-                                {% if item.job.id in favorites %}
-                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">取消</a>
-                                {% else %}
-                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
-                                {% endif %}
                             {% endif %}
                         </div>
                     </div>

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -51,7 +51,7 @@
                             <a href="{% url 'jobs:show' item.job.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
                             {% if item.can_edit %}
                                 <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' item.job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
-                                <form method="POST" action="{% url 'jobs:delete' item.job.id %}"></form>
+                                <form method="POST" action="{% url 'jobs:delete' item.job.id %}">
                                     {% csrf_token %}
                                     <button class="text-white btn btn-error btn-sm">刪除</button>
                                 </form>

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -56,7 +56,7 @@
                         <div class="text-xs font-light text-gray-500 md:text-base lg:text-base">2024/07/12</div>
                         <div class="flex items-center w-full gap-2 md:w-auto lg:w-auto">
                             <a href="{% url 'jobs:show' job.id %}" class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">詳細</a>
-                            {% if item.can_edit %}
+                            {% if job.can_edit %}
                                 <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
                                 <form method="POST" action="{% url 'jobs:delete' job.id %}">
                                     {% csrf_token %}

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -39,12 +39,11 @@
                             <div class="text-[#cccccc] cursor-pointer">
                                 {% if request.user.is_authenticated and request.user.type == 1 %}
                                 {% if item.job.id in favorites %}
-                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">取消</a>
+                                    <button class="text-error"><a href="{% url 'users:favorite' item.job.id %}"> <i class="fa-solid fa-heart"></i></a></button>
                                 {% else %}
-                                    <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
-                                {% endif %}
+                                    <button class="text-[#cccccc]"><a href="{% url 'users:favorite' item.job.id %}"> <i class="fa-regular fa-heart"></i></a></button>                                {% endif %}
                             {% endif %}
-                                <i class="fa-regular fa-heart"></i>
+
                             </div>
                         </div>
                     </div>

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -30,24 +30,16 @@
 
         <ul class="flex flex-col gap-8">
             {% for item in page_obj %}
-                <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl border border-[#e7e8eb] p-6 bg-white w-full box-border">
+                <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl bg-white border border-[#e7e8eb] p-6 bg-white w-full box-border">
                     <div class="items-center block md:flex lg:flex">
                         <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:pr-4 lg:pr-4">
                             <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{item.job.title}}</h2>
                         </div>
                         <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
-                            <div class="text-[#cccccc] cursor-pointer">
-                                {% if request.user.is_authenticated and request.user.type == 1 %}
-                                {% if item.job.id in favorites %}
-                                    <button class="text-error"><a href="{% url 'users:favorite' item.job.id %}"> <i class="fa-solid fa-heart"></i></a></button>
-                                {% else %}
-                                    <button class="text-[#cccccc]"><a href="{% url 'users:favorite' item.job.id %}"> <i class="fa-regular fa-heart"></i></a></button>                                {% endif %}
-                            {% endif %}
-
-                            </div>
+                            <div class="text-[#cccccc] cursor-pointer"><i class="fa-regular fa-heart"></i></div>
                         </div>
                     </div>
-                    <h3 class="mt-2 text-sm font-bold text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">from<a href="{% url 'companies:show' item.company.id %}">{{item.company.title}}</a></h3>
+                    <h3 class="mt-2 text-sm font-bold text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">from <a href="{% url 'companies:show' item.company.id %}">{{item.company.title}}</a></h3>
                     <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{item.job.description}}</p>
                     <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
                         <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{item.job.type}}</span>
@@ -62,8 +54,15 @@
                                 <a class="flex-auto text-base rounded-full btn btn-secondary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:flex-none" href="{% url 'jobs:edit' item.job.id %}"><i class="text-base fa-solid fa-pen lg:text-base"></i> <span>編輯</span></a>
                                 <form method="POST" action="{% url 'jobs:delete' item.job.id %}">
                                     {% csrf_token %}
-                                    <button class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl min-w-20 md:min-w-24 lg:min-w-24 lg:flex-none">刪除</button>
+                                    <button class="text-white btn btn-error btn-sm">刪除</button>
                                 </form>
+                            {% endif %}
+                            {% if  request.user.is_authenticated and request.user.type == 1 %}
+                                {% if item.job.id in favorites %}
+                                    <div class="flex gap-2 text-2xl absolute top-2.5 right-3 md:lg:static lg:static">
+                                        {% include "shared/job_favorite.html" with favorited=item.favorited %}
+                                    </div>
+                                {% endif %}
                             {% endif %}
                         </div>
                     </div>

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -63,7 +63,7 @@
                                     <a class="text-white btn btn-secondary btn-sm" href="{% url 'users:favorite' item.job.id %}">收藏</a>
                                 {% endif %}
                             {% endif %}
-                        </div>    
+                        </div>
                     </div>
                 </li>
             {% endfor %}

--- a/apps/jobs/templates/jobs/index.html
+++ b/apps/jobs/templates/jobs/index.html
@@ -30,7 +30,7 @@
 
         <ul class="flex flex-col gap-8">
             {% for item in page_obj %}
-                <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl bg-white border border-[#e7e8eb] p-6 bg-white w-full box-border">
+                <li class="relative rounded-xl md:rounded-3xl lg:rounded-3xl border border-[#e7e8eb] p-6 bg-white w-full box-border">
                     <div class="items-center block md:flex lg:flex">
                         <div class="box-border flex-1 pt-6 md:pt-0 lg:pt-0 md:pr-4 lg:pr-4">
                             <h2 class="text-xl font-semibold md:text-2xl lg:text-2xl">{{item.job.title}}</h2>
@@ -47,6 +47,7 @@
                             </div>
                         </div>
                     </div>
+                    <h3 class="mt-2 text-sm font-bold text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">from<a href="{% url 'companies:show' item.company.id %}">{{item.company.title}}</a></h3>
                     <p class="mt-2 text-sm font-light text-gray-600 md:mt-4 lg:mt-4 md:text-base lg:text-base line-clamp-2">{{item.job.description}}</p>
                     <div class="mt-2 md:mt-4 lg:mt-4 flex flex-wrap gap-1 md:gap-1.5 lg:gap-2.5 text-base font-light">
                         <span class="bg-[#fff7c7] px-2 md:px-3 lg:px-3 py-1 rounded-full text-black text-sm md:text-base lg:text-base">{{item.job.type}}</span>

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -5,6 +5,7 @@ import rules
 from django.contrib import messages
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
+from django.views.decorators.http import require_POST
 from taggit.models import Tag, TaggedItem
 
 from apps.resumes.models import Resume
@@ -77,6 +78,7 @@ def edit(request, id):
     return render(request, "jobs/edit.html", {"form": form, "job": job, "tags": tags})
 
 
+@require_POST
 def delete(request, id):
     job = get_object_or_404(Job, pk=id)
     job.mark_delete()

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -19,7 +19,7 @@ from .models import Job, Job_Resume, JobFavorite
 
 
 def index(request):
-    jobs = Job.objects.order_by("-id")
+    jobs = Job.objects.order_by("-id").select_related("company")
     jobs_with_permissions = [
         {
             "job": job,
@@ -28,10 +28,10 @@ def index(request):
                 JobFavorite.objects.filter(job=job, user=request.user).exists()
                 if request.user.is_authenticated
                 else False
-            ),
-        }
-        for job in jobs
-    ]
+            ),"company":job.company
+        } for job in jobs]
+  
+    
     page_obj = paginate_queryset(request, jobs_with_permissions, 10)
     return render(request, "jobs/index.html", {"page_obj": page_obj})
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -28,10 +28,12 @@ def index(request):
                 JobFavorite.objects.filter(job=job, user=request.user).exists()
                 if request.user.is_authenticated
                 else False
-            ),"company":job.company
-        } for job in jobs]
-  
-    
+            ),
+            "company": job.company,
+        }
+        for job in jobs
+    ]
+
     page_obj = paginate_queryset(request, jobs_with_permissions, 10)
     return render(request, "jobs/index.html", {"page_obj": page_obj})
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -22,14 +22,20 @@ def index(request):
     jobs = Job.objects.order_by("-id").select_related("company")
     jobs_with_permissions = [
         {
-            "job": job,
+            "id": job.id,
+            "title": job.title,
+            "description": job.description,
+            "type": job.type,
+            "get_location_display": job.get_location_display,
+            "salary_range": job.salary_range,
+            "company": job.company.title,
+            "company_id": job.company.id,
             "can_edit": rules.test_rule("can_edit_job", request.user, job.id),
             "favorited": (
                 JobFavorite.objects.filter(job=job, user=request.user).exists()
                 if request.user.is_authenticated
                 else False
             ),
-            "company": job.company,
         }
         for job in jobs
     ]

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -77,7 +77,6 @@ def edit(request, id):
     return render(request, "jobs/edit.html", {"form": form, "job": job, "tags": tags})
 
 
-
 def delete(request, id):
     job = get_object_or_404(Job, pk=id)
     job.mark_delete()

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -77,6 +77,7 @@ def edit(request, id):
     return render(request, "jobs/edit.html", {"form": form, "job": job, "tags": tags})
 
 
+
 def delete(request, id):
     job = get_object_or_404(Job, pk=id)
     job.mark_delete()

--- a/apps/users/templates/users/home.html
+++ b/apps/users/templates/users/home.html
@@ -51,8 +51,8 @@
         <!--card-->
         {% for job in jobs %}
           <div class="relative border border-[#cccccc] rounded-xl md:rounded-3xl lg:rounded-3xl p-6 bg-white w-full md:w-calc-card lg:w-calc-card box-border">
-            <div class="items-center flex">
-              <div class="relative w-14 h-14 md:w-20 md:h-20 lg:w-20 lg:h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
+            <div class="flex items-center">
+              <div class="relative mx-auto overflow-hidden bg-gray-200 rounded-full w-14 h-14 md:w-20 md:h-20 lg:w-20 lg:h-20 md:mx-0 lg:mx-0">
                 <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
               </div>
               <div class="box-border flex-1 pl-3 pr-4 md:px-4 lg:px-4">
@@ -78,13 +78,13 @@
                 </span>
               <span class="bg-[#e5eaf0] px-2 md:px-3 lg:px-3 py-1 rounded-full text-primary text-sm md:text-base lg:text-base"><i class="text-xs fa-solid fa-sack-dollar md:text-sm lg:text-sm"></i> ${{ job.salary }} / 月</span>
             </div>
-            <div class="flex flex-col lg:flex-row gap-4 justify-between items-start lg:items-center mt-6 md:mt-4 lg:mt-4">
-              <div class="text-gray-500 text-xs md:text-base lg:text-base font-light">{{ job.created_at|date:"Y/m/d" }}</div>
-              <div class="flex gap-4 w-full lg:w-auto">
+            <div class="flex flex-col items-start justify-between gap-4 mt-6 lg:flex-row lg:items-center md:mt-4 lg:mt-4">
+              <div class="text-xs font-light text-gray-500 md:text-base lg:text-base">{{ job.created_at|date:"Y/m/d" }}</div>
+              <div class="flex w-full gap-4 lg:w-auto">
                 {% if request.user.type != 2 and not job.apply %}
                   <form action="{% url 'users:apply_jobs' job.id %}" method="POST" class="flex flex-auto gap-4">
                     {% csrf_token%}
-                    <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl flex-auto lg:min-w-24 rounded-full">應徵</button>
+                    <button class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:min-w-24">應徵</button>
                   </form>
                 {% endif %}
               </div>
@@ -102,8 +102,8 @@
       <div class="flex flex-wrap gap-5 md:gap-7 lg:gap-10">
         {% for company in companies %}
           <div class="box-border relative w-full p-6 bg-white rounded-xl md:rounded-3xl lg:rounded-3xl shadow-custom-light md:w-calc-card lg:w-calc-card">
-            <div class="items-center flex">
-              <div class="relative w-14 h-14 md:w-20 md:h-20 lg:w-20 lg:h-20 mx-auto overflow-hidden bg-gray-200 rounded-full md:mx-0 lg:mx-0">
+            <div class="flex items-center">
+              <div class="relative mx-auto overflow-hidden bg-gray-200 rounded-full w-14 h-14 md:w-20 md:h-20 lg:w-20 lg:h-20 md:mx-0 lg:mx-0">
                 <img src="{% static 'imgs/logo.png' %}" alt="公司圖標" class="absolute w-full transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
               </div>
               <div class="box-border flex-1 pl-3 pr-4 md:px-4 lg:px-4">
@@ -125,12 +125,12 @@
                 </div>
               {% endif %}
             </div>
-            <div class="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between mt-4">
-              <div class="text-sm md:text-lg lg:text-lg font-light text-black flex-1 line-clamp-2">
+            <div class="flex flex-col items-start justify-between gap-4 mt-4 lg:flex-row lg:items-center">
+              <div class="flex-1 text-sm font-light text-black md:text-lg lg:text-lg line-clamp-2">
                   {{ company.description }}
               </div>
-              <div class="flex gap-4 w-full lg:w-auto">
-                <button class="btn btn-primary btn-sm md:btn-md lg:btn-md text-base md:text-xl lg:text-xl flex-auto rounded-full lg:min-w-24">
+              <div class="flex w-full gap-4 lg:w-auto">
+                <button class="flex-auto text-base rounded-full btn btn-primary btn-sm md:btn-md lg:btn-md md:text-xl lg:text-xl lg:min-w-24">
                   <a href="{% url 'companies:show' company.id %}">詳細</a>
                 </button>
               </div>

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -189,11 +189,9 @@ def favorite(request, id):
 
     if JobFavorite.objects.filter(user=user, job=job).exists():
         JobFavorite.objects.filter(user=user, job=job).delete()
-        messages.success(request, "取消收藏成功")
         return redirect("jobs:index")
     else:
         JobFavorite.objects.create(user=user, job=job, favorited_at=timezone.now())
-        messages.success(request, "收藏成功")
         return redirect("jobs:index")
 
 


### PR DESCRIPTION
#242 

待改之處

<img width="1440" alt="截圖 2024-09-22 03 34 39" src="https://github.com/user-attachments/assets/74e091c0-ddd5-47cd-bb17-e89f90b2384f">


1.個人使用者收藏/取消收藏某一個職缺時，會跳轉

<img width="1440" alt="截圖 2024-09-22 03 34 59" src="https://github.com/user-attachments/assets/1e4975ff-d398-43e3-b457-c7e76ccd822f">
2.公司頁面的職缺，有新增職缺、編輯及刪除，刪除鍵需要改顏色

3.公司刪除某的職缺後，會導引到使用者觀看的職缺頁面 
（公司原本是在 company/ id / jobs  刪除後網址會來到  company / jobs ，變成看到所有的職缺）

https://github.com/user-attachments/assets/0a07cbc6-4bab-4973-8919-70a1df318553

