### PR TITLE
Issues/251 修復_搜尋結果頁

### DIFF
--- a/apps/jobs/templates/jobs/search_results.html
+++ b/apps/jobs/templates/jobs/search_results.html
@@ -16,7 +16,7 @@
         {% for job in page_obj %}
         <li class="flex gap-2 p-5" id="job-{{ job.id }}">
             <div class="flex-1">
-                <a class="text-xl font-medium" href="{% url 'jobs:show' job.id %}">{{ job.title }}</a>
+                <a class="text-xl font-medium" href="{% url 'jobs:show' job.id %}?q={{ search_term }}&location={{ location }}&page={{ page_obj.number }}">{{ job.title }}</a>
                 <p class="text-small">{{ job.company.title }}, {{ job.get_location_display }}</p>
             </div>
             <div class="flex gap-2">

--- a/apps/jobs/templates/jobs/search_results.html
+++ b/apps/jobs/templates/jobs/search_results.html
@@ -1,11 +1,13 @@
 {% extends "layouts/base.html" %}
 {% block content %}
-<div class="flex items-center justify-center h-24 mt-20 text-center bg-gray-100">
-    <h1 class="text-3xl font-bold">
+<div class="relative flex items-center justify-center overflow-hidden text-center h-44 md:h-80 lg:h-80">
+    <h1 class="relative z-20 text-3xl font-bold text-white md:text-5xl lg:text-5xl">
         搜尋結果:
         {% if search_term %}{{ search_term }}{% endif %}
         {% if location %}{{ location }}{% endif %}
     </h1>
+    <div class="absolute inset-0 z-10 m-auto bg-fixed bg-center bg-cover bg-banner-img"></div>
+    <div class="absolute z-10 m-auto inset-0 bg-gradient-to-b from-[rgba(68,157,209,0.9)] to-[rgba(0,51,107,0.9)]"></div>
 </div>
 <div class="container p-5 pb-24 mx-auto">
 
@@ -28,7 +30,6 @@
         <p>沒有找到符合的工作。</p>
         {% endif %}
     </ul>
-
     {% include 'shared/_pagination.html' %}
 </div>
 {% endblock %}

--- a/apps/jobs/templates/jobs/search_results.html
+++ b/apps/jobs/templates/jobs/search_results.html
@@ -18,7 +18,9 @@
                 <p class="text-small">{{ job.company.title }}, {{ job.get_location_display }}</p>
             </div>
             <div class="flex gap-2">
-                <a class="text-white btn btn-primary min-w-20" href="{% url 'users:apply_jobs' job.id %}">應徵</a>
+                {% if user.type == 1 %}
+                    <a class="text-white btn btn-primary min-w-20" href="{% url 'users:apply_jobs' job.id %}">應徵</a>
+                {% endif %}
             </div>
         </li>
         {% endfor %}

--- a/apps/jobs/templates/jobs/search_results.html
+++ b/apps/jobs/templates/jobs/search_results.html
@@ -20,7 +20,7 @@
                 <p class="text-small">{{ job.company.title }}, {{ job.get_location_display }}</p>
             </div>
             <div class="flex gap-2">
-                {% if user.type == 1 %}
+                {% if user.type == 1 and job.id not in applied_job_ids %}
                     <a class="text-white btn btn-primary min-w-20" href="{% url 'users:apply_jobs' job.id %}">應徵</a>
                 {% endif %}
             </div>

--- a/apps/jobs/templates/jobs/show.html
+++ b/apps/jobs/templates/jobs/show.html
@@ -26,7 +26,7 @@
     {% endif %}
 
     {% if is_search_result %}
-      <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:search_results' %}?q={{ search_query }}">返回搜尋頁</a>
+      <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:search_results' %}?q={{ search_query }}&location={{ location }}">返回搜尋頁</a>
     {% elif backJobs %}
       <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:index' %}">返回列表</a>
     {% else %}

--- a/apps/jobs/templates/jobs/show.html
+++ b/apps/jobs/templates/jobs/show.html
@@ -26,7 +26,7 @@
     {% endif %}
 
     {% if is_search_result %}
-      <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:search_results' %}?q={{ search_query }}&location={{ location }}">返回搜尋頁</a>
+      <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:search_results' %}?q={{ search_query }}&location={{ location }}&page={{ request.GET.page }}">返回搜尋頁</a>
     {% elif backJobs %}
       <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:index' %}">返回列表</a>
     {% else %}

--- a/apps/jobs/templates/jobs/show.html
+++ b/apps/jobs/templates/jobs/show.html
@@ -12,19 +12,22 @@
     <ul class="mb-4">
         <li>工作敘述：{{ job.description }}</li>
         <li>工作地點：{{ job.get_location_display }}</li>
-      </ul>
-      {% if request.user.is_authenticated %}
-        <form action="{% url 'users:apply_jobs' job.id %}" method="POST">
-          {% csrf_token %}
-          <input type="hidden" name="job_id" value="{{ job.id }}">
-          {% if status == False %}
-            <button class="mb-4 text-white btn btn-secondary btn-sm">應徵</button>
-          {% endif %}
-        </form>
-      {% else %}
-        <p>請登入以應徵此工作。</p>
-      {% endif %}
-    {% if backJobs %}
+    </ul>
+    {% if request.user.is_authenticated %}
+      <form action="{% url 'users:apply_jobs' job.id %}" method="POST">
+        {% csrf_token %}
+        <input type="hidden" name="job_id" value="{{ job.id }}">
+        {% if status == False %}
+          <button class="mb-4 text-white btn btn-secondary btn-sm">應徵</button>
+        {% endif %}
+      </form>
+    {% else %}
+      <a href="{% url 'users:sign_in' %}?next={% url 'users:apply_jobs' job.id %}" class="text-white btn btn-primary">登入應徵</a>
+    {% endif %}
+
+    {% if is_search_result %}
+      <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:search_results' %}?q={{ search_query }}">返回搜尋頁</a>
+    {% elif backJobs %}
       <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:index' %}">返回列表</a>
     {% else %}
       <a class="text-white btn btn-primary min-w-20" href="{% url 'resumes:jobs' %}">返回</a>

--- a/apps/jobs/templates/jobs/show.html
+++ b/apps/jobs/templates/jobs/show.html
@@ -13,13 +13,21 @@
         <li>工作敘述：{{ job.description }}</li>
         <li>工作地點：{{ job.get_location_display }}</li>
       </ul>
-      <form action="{% url 'users:apply_jobs' job.id %}" method="POST">
-        {% csrf_token%}
-        <input type="hidden" name="job_id" value="{{ job.id }}">
-        {% if status == False %}
-          <button class="mb-4 text-white btn btn-secondary btn-sm">應徵</button>
-        {% endif %}
-      </form>
-      <a class="text-white btn btn-primary min-w-20" onclick="history.back();">返回列表</a>
+      {% if request.user.is_authenticated %}
+        <form action="{% url 'users:apply_jobs' job.id %}" method="POST">
+          {% csrf_token %}
+          <input type="hidden" name="job_id" value="{{ job.id }}">
+          {% if status == False %}
+            <button class="mb-4 text-white btn btn-secondary btn-sm">應徵</button>
+          {% endif %}
+        </form>
+      {% else %}
+        <p>請登入以應徵此工作。</p>
+      {% endif %}
+    {% if backJobs %}
+      <a class="text-white btn btn-primary min-w-20" href="{% url 'jobs:index' %}">返回列表</a>
+    {% else %}
+      <a class="text-white btn btn-primary min-w-20" href="{% url 'resumes:jobs' %}">返回</a>
+    {% endif %}
 </div>
 {% endblock %}

--- a/apps/jobs/templates/jobs/show.html
+++ b/apps/jobs/templates/jobs/show.html
@@ -17,7 +17,7 @@
       <form action="{% url 'users:apply_jobs' job.id %}" method="POST">
         {% csrf_token %}
         <input type="hidden" name="job_id" value="{{ job.id }}">
-        {% if status == False %}
+        {% if status == False and request.user.type == 1 %}
           <button class="mb-4 text-white btn btn-secondary btn-sm">應徵</button>
         {% endif %}
       </form>

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -154,6 +154,7 @@ def search_results(request):
             resume__userinfo__user=request.user
         ).values_list("job_id", flat=True)
 
+    current_page = request.GET.get("page", 1)
     page_obj = paginate_queryset(request, jobs, 10)
     all_tags = Tag.objects.all()
 
@@ -170,5 +171,6 @@ def search_results(request):
             "search_term": search_term,
             "location": location_label,
             "applied_job_ids": list(applied_job_ids),
+            "current_page": current_page,
         },
     )

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -148,6 +148,12 @@ def search_results(request):
         .order_by("created_at")
     )
 
+    applied_job_ids = []
+    if request.user.is_authenticated:
+        applied_job_ids = Job_Resume.objects.filter(
+            resume__userinfo__user=request.user
+        ).values_list("job_id", flat=True)
+
     page_obj = paginate_queryset(request, jobs, 10)
     all_tags = Tag.objects.all()
 
@@ -163,5 +169,6 @@ def search_results(request):
             "all_tags": all_tags,
             "search_term": search_term,
             "location": location_label,
+            "applied_job_ids": list(applied_job_ids),
         },
     )

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -62,7 +62,11 @@ def show(request, id):
         else:
             return render(request, "jobs/edit.html", {"form": form, "job": job})
 
-    status = True
+    previous_url = request.META.get("HTTP_REFERER", "/")
+    referer_path = urlparse(previous_url).path
+    backJobs = "resumes" not in referer_path
+    status = False
+
     if request.user.is_authenticated and request.user.type == 1:
         user_info = UserInfo.objects.get(user=request.user)
         user_resume = Resume.objects.filter(userinfo=user_info).values_list(

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1,5 +1,5 @@
 import json
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import rules
 from django.contrib import messages
@@ -64,20 +64,38 @@ def show(request, id):
 
     previous_url = request.META.get("HTTP_REFERER", "/")
     referer_path = urlparse(previous_url).path
+    parsed_url = urlparse(previous_url)
+    query_params = parse_qs(parsed_url.query)
+
     backJobs = "resumes" not in referer_path
+    is_search_result = "search" in referer_path
+    search_query = query_params.get("q", [""])[0]
+    location = query_params.get("location", [""])[0]
+
     status = False
 
     if request.user.is_authenticated and request.user.type == 1:
-        user_info = UserInfo.objects.get(user=request.user)
-        user_resume = Resume.objects.filter(userinfo=user_info).values_list(
-            "id", flat=True
-        )
-        status = Job_Resume.objects.filter(job=job, resume__in=user_resume).exists()
+        try:
+            user_info = UserInfo.objects.get(user=request.user)
+            user_resume = Resume.objects.filter(userinfo=user_info).values_list(
+                "id", flat=True
+            )
+            status = Job_Resume.objects.filter(job=job, resume__in=user_resume).exists()
+        except UserInfo.DoesNotExist:
+            user_info = None
 
     return render(
         request,
         "jobs/show.html",
-        {"job": job, "tags": job.tags.all(), "status": status},
+        {
+            "job": job,
+            "backJobs": backJobs,
+            "tags": job.tags.all(),
+            "status": status,
+            "is_search_result": is_search_result,
+            "search_query": search_query,
+            "location": location,
+        },
     )
 
 

--- a/apps/users/templates/users/apply.html
+++ b/apps/users/templates/users/apply.html
@@ -22,7 +22,7 @@
           {% endfor %}
         </select>
       <button class="text-white btn btn-error btn-sm" >提交申請</button>
-      <button class="text-white btn btn-error btn-sm" ><a href="{% url 'jobs:index' %}">取消</a></button>
+      <button class="text-white btn btn-error btn-sm" ><a href="{% url 'jobs:show' job.id %}">取消</a></button>
     </form>
   </div>
 </div>

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -257,12 +257,12 @@ def submit_jobs(request, job_id):
 
     if Job_Resume.objects.filter(job=job, resume=resume).exists():
         messages.error(request, "已投遞過這個工作，請等候業者審核等候通知，謝謝")
-        return redirect("jobs:index")
+        return redirect("jobs:show", id=job.id)
 
     else:
         Job_Resume.objects.create(job=job, resume=resume, status="applied")
         messages.success(request, "投遞成功")
-        return redirect("jobs:index")
+        return redirect("jobs:show", id=job.id)
 
 
 @login_required

--- a/templates/shared/_pagination.html
+++ b/templates/shared/_pagination.html
@@ -1,26 +1,30 @@
 <div class="mt-10 md:mt-20 lg:mt-20">
-    <div class="flex gap-2 justify-center">
+    <div class="flex justify-center gap-2">
         {% if page_obj.has_previous %}
-            <a class="flex justify-center items-center w-10 h-10 bg-secondary rounded-lg" href="?page=1">
+            <a class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary"
+                href="?page=1{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.location %}&location={{ request.GET.location }}{% endif %}">
                 <div class="w-0.5 h-4 bg-white"></div>
                 <div class="w-0 h-0 border-t-8 border-b-8 border-r-8 border-transparent border-r-white"></div>
             </a>
-            <a class="flex justify-center items-center w-10 h-10 bg-secondary rounded-lg" href="?page={{ page_obj.previous_page_number }}">
+            <a class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary"
+                href="?page={{ page_obj.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.location %}&location={{ request.GET.location }}{% endif %}">
                 <div class="w-0 h-0 border-t-8 border-b-8 border-r-8 border-transparent border-r-white"></div>
             </a>
         {% endif %}
 
-        <span class="flex justify-center items-center w-16 h-10 bg-white text-xl rounded-lg">{{ page_obj.number }}</span>
+        <span class="flex items-center justify-center w-16 h-10 text-xl bg-white rounded-lg">{{ page_obj.number }}</span>
 
         {% if page_obj.has_next %}
-            <a class="flex justify-center items-center w-10 h-10 bg-secondary rounded-lg" href="?page={{ page_obj.next_page_number }}">
+            <a class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary"
+                href="?page={{ page_obj.next_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.location %}&location={{ request.GET.location }}{% endif %}">
                 <div class="w-0 h-0 border-t-8 border-b-8 border-l-8 border-transparent border-l-white"></div>
             </a>
-            <a class="flex justify-center items-center w-10 h-10 bg-secondary rounded-lg" href="?page={{ page_obj.paginator.num_pages }}">
+            <a class="flex items-center justify-center w-10 h-10 rounded-lg bg-secondary"
+                href="?page={{ page_obj.paginator.num_pages }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.location %}&location={{ request.GET.location }}{% endif %}">
                 <div class="w-0 h-0 border-t-8 border-b-8 border-l-8 border-transparent border-l-white"></div>
                 <div class="w-0.5 h-4 bg-white"></div>
             </a>
         {% endif %}
     </div>
-    <div class="text-center mt-4">總共 {{ page_obj.paginator.num_pages }} 頁</div>
+    <div class="mt-4 text-center">總共 {{ page_obj.paginator.num_pages }} 頁</div>
 </div>


### PR DESCRIPTION
#251 

1. 修復未登入用戶&公司方搜尋後，點職缺報錯問題
2. 增加判斷：
   - 搜尋結果列表(search_results)：
      1) 未登入用戶&公司方不顯示應徵按鈕
   - 職缺詳細內容(show)：
     1) 未登入用戶：顯示「登入應徵」按鈕
     2) 公司方：不顯示「登入應徵」按鈕
     3) 已登入用戶：顯示「應徵」按鈕
     4) 按「返回搜尋頁」會回到搜尋結果列表
   - 應徵頁(apply)：
     1) 按「取消」會回到搜尋結果列表

https://github.com/user-attachments/assets/36825a93-ca65-4733-8a25-4352751e3cb0
