### PR TITLE
issues/396 修正_linepay部署設定

### DIFF
--- a/apps/payments/views.py
+++ b/apps/payments/views.py
@@ -36,8 +36,8 @@ def request(request):
                 }
             ],
             "redirectUrls": {
-                "confirmUrl": f"http://{os.getenv('HOSTNAME')}/payments/confirm",
-                "cancelUrl": f"http://{os.getenv('HOSTNAME')}/payments/cancel",
+                "confirmUrl": f"{os.getenv('HOSTNAME')}payments/confirm",
+                "cancelUrl": f"{os.getenv('HOSTNAME')}payments/cancel",
             },
         }
 


### PR DESCRIPTION
為了因應部署所需，將linepay的comfirm url改成heroku部署設定

*改成此版本，本機跑linepay付款成功後無法返回頁面