### PR TITLE
issues/462 修正_薪資註解縮小

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -3,10 +3,10 @@ from urllib.parse import parse_qs, urlparse
 
 import rules
 from django.contrib import messages
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
-from django.contrib.contenttypes.models import ContentType
 from taggit.models import Tag, TaggedItem
 
 from apps.resumes.models import Resume

--- a/src/scripts/chart.js
+++ b/src/scripts/chart.js
@@ -196,7 +196,7 @@ document.addEventListener("DOMContentLoaded", function () {
           x: {
             ticks: {
               font: {
-                size: 20,
+                size: 10,
               },
             },
           },

--- a/src/scripts/chart.js
+++ b/src/scripts/chart.js
@@ -166,8 +166,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const salaryElement = document.getElementById("averageSalaryData");
   if (salaryElement) {
     const salaryData = JSON.parse(salaryElement.textContent);
-    const salaryLabels = Object.keys(salaryData);
-    const salaryValues = Object.values(salaryData);
+    const salaryLabels = Object.keys(salaryData).slice(0, 10);
+    const salaryValues = Object.values(salaryData).slice(0, 10);
 
     const salaryCtx = document.getElementById("salaryChart").getContext("2d");
     const salaryChart = new Chart(salaryCtx, {


### PR DESCRIPTION
### 調整薪資註解大小，以確保其他註解不會被吃掉。
- #462 

### 字太大就會擠掉旁邊的
<img width="672" alt="image" src="https://github.com/user-attachments/assets/bd63c5fe-5ef4-420d-aca5-bac1dec5081a">


<img width="682" alt="截圖 2024-09-30 上午11 15 35" src="https://github.com/user-attachments/assets/41b47670-596b-49bd-9e67-678406ed7846">
